### PR TITLE
defaulting to 700 seconds shutdown_on_missing_block_import 

### DIFF
--- a/template-validator.toml
+++ b/template-validator.toml
@@ -19,7 +19,7 @@ gas_floor_target = "300000000"
 [misc]
 log_file = "diamond-node.log"
 logging = "txqueue=info,consensus=info,engine=info,hbbft_message_memorium=error"
-shutdown_on_missing_block_import = 1800
+shutdown_on_missing_block_import = 700
 
 [network]
 interface = "all"


### PR DESCRIPTION
as default in the template validator.